### PR TITLE
docs: clarify units

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,9 @@ CREATE TABLE nodes_ecs
 (
     -- auto generated, doesn't need to be set manually
     id             INT GENERATED ALWAYS AS IDENTITY,
-    -- available CPU
+    -- available CPUs
     cpu            INT         NOT NULL,
-    -- available memory
+    -- available memory rounded to the nearest MB
     memory         INT         NOT NULL,
     -- the peer ID of the libp2p host
     peer_id        TEXT        NOT NULL,


### PR DESCRIPTION
The `memory` field is too small to report memory in bytes (Postgres INT is 4 byte signed integer so max 2GB).

The ECS container metadata reports memory in MB and CPU as the number of CPUs (I assume?), so clarify those as the expected units in the README.