### PR TITLE
fix: wait for two ready clients rather than not 0

### DIFF
--- a/cmd/parsec/cmd_scheduler.go
+++ b/cmd/parsec/cmd_scheduler.go
@@ -72,7 +72,7 @@ func SchedulerAction(c *cli.Context) error {
 		}
 
 		if len(dbNodes) < 2 {
-			log.WithField("fleets", config.Scheduler.Fleets.Value()).Infoln("Less than two nodes in database. Waiting 10s and then trying again...")
+			log.WithField("fleets", config.Scheduler.Fleets.Value()).Infoln("Fewer than two nodes in database. Waiting 10s and then trying again...")
 			select {
 			case <-time.After(10 * time.Second):
 				continue
@@ -98,8 +98,8 @@ func SchedulerAction(c *cli.Context) error {
 			clients = append(clients, client)
 		}
 
-		if len(clients) == 0 {
-			log.WithField("fleets", config.Scheduler.Fleets.Value()).Infoln("Less than two nodes ready. Waiting 10s and then trying again...")
+		if len(clients) < 2 {
+			log.WithField("fleets", config.Scheduler.Fleets.Value()).Infoln("Fewer than two nodes ready. Waiting 10s and then trying again...")
 			select {
 			case <-time.After(10 * time.Second):
 				continue


### PR DESCRIPTION
Test that two clients are ready rather than the number of ready clients not being 0.

Fixes a panic caused by clients being slow to start up (I think):

```
parsec-scheduler  | time="2024-05-15T09:34:10Z" level=info msg="GET http://172.19.0.3:7070/readiness"
parsec-scheduler  | time="2024-05-15T09:34:10Z" level=warning msg="Node not ready" error="create retrieve request: Get \"http://172.19.0.3:7070/readiness\": dial tcp 172.19.0.3:7070: connect: connection refused" nodeID=17
parsec-scheduler  | time="2024-05-15T09:34:10Z" level=debug msg="Update node offline 17"
parsec-scheduler  | time="2024-05-15T09:34:10Z" level=info msg="GET http://172.19.0.5:7070/readiness"
parsec-server-1   | 2024-05-15T09:34:10.906Z parsec:service GET /readiness
parsec-scheduler  | time="2024-05-15T09:34:10Z" level=info msg="POST http://172.19.0.5:7070/provide" cid=QmbsSUWuufi6AKc6kQnoneWZZD3sE1hxN3hEcWhbUdNRK3
parsec-server-1   | 2024-05-15T09:34:10.916Z parsec:service POST /provide
parsec-server-1   | 2024-05-15T09:34:10.917Z parsec:service start providing bafkreigjbmnaxwaklzrlcanf4pfgkalt54k4hruxrrypgojctzd5fgx2ly
parsec-server-2   | time="2024-05-15T09:34:13Z" level=debug msg="Update heartbeat 19"
parsec-server-2   | time="2024-05-15T09:34:16Z" level=info msg="New reachability: Private"
parsec-server-1   | 2024-05-15T09:35:01.537Z parsec:heartbeat update heartbeat 18
parsec-server-2   | time="2024-05-15T09:35:13Z" level=debug msg="Update heartbeat 19"
parsec-server-1   | 2024-05-15T09:35:32.374Z parsec:service published provider record to 12D3KooWJrZhYu4W1zt719wWfyfrKXjYFdeohTDaHiN7GbSjPkxy after 81457ms
parsec-server-1   | 2024-05-15T09:35:32.947Z parsec:service published provider record to 12D3KooWSuuyv5qnvuPjFBQix85Qi8J8zNDpdf1XaYA8vo5XkpSe after 82030ms
parsec-server-1   | 2024-05-15T09:35:33.697Z parsec:service published provider record to 12D3KooWQGATXTi8dSYDSVb4cx54oZ3kjRTxZAor6jmEDHxYUPAT after 82780ms
parsec-server-1   | 2024-05-15T09:35:34.414Z parsec:service published provider record to QmYGVgGGfD5N4Xcc78CcMJ99dKcH6K6myhd4Uenv5yJwiJ after 83497ms
parsec-server-1   | 2024-05-15T09:35:35.147Z parsec:service published provider record to 12D3KooW9woLyUp2hsN9khKJpn5Fu1AEkqxJNr3M8fZF4cLvLNcg after 84230ms
parsec-server-1   | 2024-05-15T09:35:36.326Z parsec:service published provider record to 12D3KooWFnds6EzLtg8iHFY4kgx5vdgB8iWsJqizB3mnawUqCmQX after 85409ms
parsec-server-1   | 2024-05-15T09:35:37.365Z parsec:service done publishing provider records for bafkreigjbmnaxwaklzrlcanf4pfgkalt54k4hruxrrypgojctzd5fgx2ly after 86447ms - routing table size 3173
parsec-scheduler  | panic: runtime error: index out of range [1] with length 1
parsec-scheduler  | 
parsec-scheduler  | goroutine 1 [running]:
parsec-scheduler  | main.SchedulerAction(0xc0004d8500)
parsec-scheduler  |     /build/cmd/parsec/cmd_scheduler.go:152 +0x15a5
parsec-scheduler  | github.com/urfave/cli/v2.(*Command).Run(0x25733c0, 0xc0004d8500, {0xc000235de0, 0x1, 0x1})
parsec-scheduler  |     /go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/command.go:273 +0x9eb
parsec-scheduler  | github.com/urfave/cli/v2.(*Command).Run(0xc00031c420, 0xc0004d8040, {0xc00003e040, 0x2, 0x2})
parsec-scheduler  |     /go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/command.go:266 +0xc4d
parsec-scheduler  | github.com/urfave/cli/v2.(*App).RunContext(0xc0004fc780, {0x1b397d0?, 0xc00008b900}, {0xc00003e040, 0x2, 0x2})
parsec-scheduler  |     /go/pkg/mod/github.com/urfave/cli/v2@v2.24.4/app.go:332 +0x616
parsec-scheduler  | main.main()
parsec-scheduler  |     /build/cmd/parsec/parsec.go:179 +0x16e5
```

Also fixes `Less` -> `Fewer` typos.